### PR TITLE
linux-intel_%.bbappend: fix the spacing in the SRC_URI_append

### DIFF
--- a/recipes-kernel/linux/linux-intel_%.bbappend
+++ b/recipes-kernel/linux/linux-intel_%.bbappend
@@ -16,9 +16,10 @@ SRC_URI = " \
 #    git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;name=machine;branch=${LINUX_X86_BRANCH} \
 #    "
 
-SRC_URI_append = "file://defconfig \
-		  file://can-and-lcd-devices.cfg \
-		"
+SRC_URI_append = " \
+	file://defconfig \
+	file://can-and-lcd-devices.cfg \
+	"
 
 include ${@mender_feature_is_enabled("mender-client-install","linux-intel-mender.inc","",d)}
 


### PR DESCRIPTION
A space is missing to properly concatenate SRC_URI. It's causing an error:
* in meta-intel SRC_URI_append = " file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patch"
* in the bbapend SRC_URI_append = "file://defconfig \ As a result, SRC_URI is computed as
"file://0001-menuconfig-mconf-cfg-Allow-specification-of-ncurses-.patchfile://defconfig"

Add a space to fix the issue.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>