### PR TITLE
make MENDER_ARTIFACT_NAME a weak assignment

### DIFF
--- a/conf/machine/odyssey-x86-mender.conf
+++ b/conf/machine/odyssey-x86-mender.conf
@@ -14,7 +14,7 @@ INITRAMFS_MAXSIZE = "393216"
 
 INHERIT += "mender-full"
 
-MENDER_ARTIFACT_NAME = "release-1"
+MENDER_ARTIFACT_NAME ??= "release-1"
 DISTRO_FEATURES:append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"


### PR DESCRIPTION
MENDER_ARTIFACT_NAME should be easily overridden by other layers or build conf.