### PR TITLE
Allow to override MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT and MENDER_BOO…

### DIFF
--- a/conf/machine/odyssey-x86-mender.conf
+++ b/conf/machine/odyssey-x86-mender.conf
@@ -19,8 +19,8 @@ DISTRO_FEATURES:append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
-MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "4096"
-MENDER_BOOT_PART_SIZE_MB = "64"
+MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT ??= "4096"
+MENDER_BOOT_PART_SIZE_MB ??= "64"
 # By default MENDER_DATA_PART_SIZE_MB=128MB and it will try to resize 
 # the partition on first boot to the full size of the remaining space
 MENDER_IMAGE_BOOTLOADER_FILE = "wic-initrd"


### PR DESCRIPTION
…T_PART_SIZE_MB

Make MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT and MENDER_BOOT_PART_SIZE_MB a weak assignment. It allows to override them per project, in local.conf for example.